### PR TITLE
chore: silent linebreak rule that doesnt work on windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -80,7 +80,7 @@ rules:
   space-in-parens: [2, never]
   space-unary-ops: [2, {words: true, nonwords: false}]
   wrap-regex: 2
-  linebreak-style: [2, unix]
+  linebreak-style: 0
   semi: [2, always]
   arrow-spacing: [2, {before: true, after: true}]
   no-class-assign: 2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- silent linebreak rule that doesnt work on windows

**Related issue(s)**
See also https://github.com/asyncapi/generator-hooks/pull/21